### PR TITLE
feat: implement copy button

### DIFF
--- a/umh.docs.umh.app/config.toml
+++ b/umh.docs.umh.app/config.toml
@@ -78,6 +78,7 @@ section = ["HTML"]
 copyright = "UMH Systems GmbH"
 privacy_policy = "https://www.umh.app/data-security"
 favicon = "favicon.png"
+custom_css = ["css/copy-button.css"]
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]
 
@@ -107,6 +108,9 @@ archived_version = false
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
 url_latest_version = "https://umh.docs.umh.app"
+
+# See codenew shortcode
+githubWebsiteRaw = "raw.githubusercontent.com/united-manufacturing-hub/umh.docs.umh.app"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/united-manufacturing-hub/umh.docs.umh.app"

--- a/umh.docs.umh.app/content/en/docs/development/contribute/documentation/style/hugo-shortcodes/index.md
+++ b/umh.docs.umh.app/content/en/docs/development/contribute/documentation/style/hugo-shortcodes/index.md
@@ -21,6 +21,9 @@ After you add a new file with a code snippet in the `examples` directory, you ca
 reference it in your documentation using the `codenew` shortcode with the `file`
 parameter set to the path to the file, relative to the `examples` directory.
 
+A *Copy* button is automatically added to the code snippet. When the user clicks
+the button, the code is copied to the clipboard.
+
 Here's an example:
 
 ```go-html-template

--- a/umh.docs.umh.app/layouts/partials/head.html
+++ b/umh.docs.umh.app/layouts/partials/head.html
@@ -45,4 +45,8 @@
 <!-- stylesheet for Prism -->
 <link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
 {{ end }}
+{{/*  css  */}}
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}
 {{ partial "head-typesense"}}

--- a/umh.docs.umh.app/layouts/partials/hooks/body-end.html
+++ b/umh.docs.umh.app/layouts/partials/hooks/body-end.html
@@ -1,0 +1,4 @@
+{{/* copy-and-paste helper for codenew shortcode */}}
+{{- if .HasShortcode "codenew" -}}
+<script type="text/javascript" src="/js/copy-button.js"></script>
+{{- end -}}

--- a/umh.docs.umh.app/layouts/shortcodes/codenew.html
+++ b/umh.docs.umh.app/layouts/shortcodes/codenew.html
@@ -4,7 +4,7 @@
 {{ $fileDir := path.Split $file }}
 {{ $bundlePath := path.Join .Page.File.Dir $fileDir.Dir }}
 {{ $filename := printf "/content/%s/examples/%s" .Page.Lang $file | safeURL }}
-{{ $ghlink := printf "https://%s/%s%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
+{{ $ghlink := printf "https://%s/%s/umh.docs.umh.app%s" site.Params.githubwebsiteraw (default "main" site.Params.docsbranch) $filename | safeURL }}
 {{/* First assume this is a bundle and the file is inside it. */}}
 {{ $resource := $p.Resources.GetMatch (printf "%s*" $file ) }}
 {{ with $resource }}
@@ -18,15 +18,24 @@
 {{ errorf "[%s] %q not found in %q" site.Language.Lang $fileDir.File $bundlePath }}
 {{ end }}
 {{ with $.Scratch.Get "content" }}
-<div class="highlight">
-    <div class="copy-code-icon" style="text-align:right">
-    {{ with $ghlink }}<a href="{{ . }}" download="{{ $file }}">{{ end }}<code>{{ $file }}</code>
-    {{ if $ghlink }}</a>{{ end }}
-    <img src="{{ "images/copycode.svg" | relURL }}" style="max-height:24px; cursor: pointer" onclick="copyCode('{{ $file | anchorize }}')" title="Copy {{ $file }} to clipboard">
-    </img>
-    </div>
-    <div class="includecode" id="{{ $file | anchorize }}">
+<div class="td-content includecode" id="{{ $file | anchorize }}">
     {{ highlight . $codelang "" }}
-    </div>
+    <script type="text/javascript">
+        document.querySelectorAll('pre > code').forEach(function (codeBlock) {
+            var link = document.createElement('a');
+            link.target = '_blank';
+            link.download = '{{ $file }}';
+            link.href = '{{ $ghlink }}';
+            link.innerHTML = '<code>{{ $file }}</code>';
+            link.classList = 'include-ref'
+
+            var pre = codeBlock.parentNode;
+            var includecode = pre.parentNode;
+            if (pre.parentNode.classList.contains('highlight') && includecode.parentNode.classList.contains('includecode')) {
+                var highlight = pre.parentNode;
+                pre.parentNode.insertBefore(link, highlight.children[0]);
+            }
+        });
+    </script>
 </div>
 {{ end }}

--- a/umh.docs.umh.app/static/css/copy-button.css
+++ b/umh.docs.umh.app/static/css/copy-button.css
@@ -1,0 +1,44 @@
+.copy-code-button {
+    color: #272822;
+    background-color: #FFF;
+    border-color: #272822;
+    border: 2px solid;
+    border-radius: 3px;
+
+    /* right-align */
+    margin-left: auto;
+    margin-right: 0;
+
+    right: 0;
+    top: 0;
+
+    padding: 3px 8px;
+    font-size: 0.8em;
+}
+
+.copy-code-button:hover {
+    cursor: pointer;
+    background-color: #F2F2F2;
+}
+
+.copy-code-button:focus {
+    /* Avoid an ugly focus outline on click in Chrome,
+       but darken the button for accessibility.
+       See https://stackoverflow.com/a/25298082/1481479 */
+    background-color: #E6E6E6;
+    outline: 0;
+}
+
+.copy-code-button:active {
+    background-color: #D9D9D9;
+}
+
+.highlight pre {
+    /* Avoid pushing up the copy buttons. */
+    margin: 0;
+}
+
+.include-ref {
+    position: absolute;
+    top: 0;
+}

--- a/umh.docs.umh.app/static/js/copy-button.js
+++ b/umh.docs.umh.app/static/js/copy-button.js
@@ -1,0 +1,44 @@
+function addCopyButtons(clipboard) {
+    document.querySelectorAll('pre > code').forEach(function (codeBlock) {
+        var button = document.createElement('button');
+        button.className = 'copy-code-button';
+        button.type = 'button';
+        button.innerText = 'Copy';
+
+        button.addEventListener('click', function () {
+            clipboard.writeText(codeBlock.innerText).then(function () {
+                /* Chrome doesn't seem to blur automatically,
+                   leaving the button in a focused state. */
+                button.blur();
+
+                button.innerText = 'Copied!';
+
+                setTimeout(function () {
+                    button.innerText = 'Copy';
+                }, 2000);
+            }, function (error) {
+                button.innerText = 'Error';
+            });
+        });
+
+        var pre = codeBlock.parentNode;
+        var includecode = pre.parentNode;
+        if (pre.parentNode.classList.contains('highlight') && includecode.parentNode.classList.contains('includecode')) {
+            var highlight = pre.parentNode;
+            pre.parentNode.insertBefore(button, highlight.children[1]);
+        }
+    });
+}
+if (navigator && navigator.clipboard) {
+    addCopyButtons(navigator.clipboard);
+} else {
+    var script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/clipboard-polyfill/2.7.0/clipboard-polyfill.promise.js';
+    script.integrity = 'sha256-waClS2re9NUbXRsryKoof+F9qc1gjjIhc2eT7ZbIv94=';
+    script.crossOrigin = 'anonymous';
+    script.onload = function() {
+        addCopyButtons(clipboard);
+    };
+
+    document.body.appendChild(script);
+}


### PR DESCRIPTION
# Description

This PR implements the javascript function needed to have a working *Copy* button in code snippets created with the `codenew` shortcode

### Related issues

Fix #46 

## Type of change

What types of changes does your code introduce to this project?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

An example can be found in `/docs/development/contribute/documentation/style/hugo-shortcodes/#code-example`