### PR TITLE
ci: drop collection before new scrape

### DIFF
--- a/.github/workflows/update-search.yaml
+++ b/.github/workflows/update-search.yaml
@@ -21,5 +21,9 @@ jobs:
           TYPESENSE_PORT: 443
           TYPESENSE_PROTOCOL: https
         run: |
+          COLLECTION=$(cat config-umh.docs.json | jq -r '.index_name')
+          curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
+          -X DELETE \
+          "${TYPESENSE_PROTOCOL}://${TYPESENSE_HOST}/collections/${COLLECTION}"
           CONFIG=$(cat config-umh.docs.json | jq -r tostring)
           docker run -it -e "CONFIG=$CONFIG" --network host typesense/docsearch-scraper


### PR DESCRIPTION
# Description

This PR adds a curl command to drop the collection before a new search scrape

### Related issues

Fixes #78 

## Type of change

What types of changes does your code introduce to this project?

- [x] CI

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
