### PR TITLE
Add missing step in MQTT RBAC guide

### DIFF
--- a/umh.docs.umh.app/content/en/docs/production-guide/security/enable-rbac-mqtt-broker.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/enable-rbac-mqtt-broker.md
@@ -62,6 +62,8 @@ Now all MQTT connections require password authentication with the following defa
 11. In the `data.credentials.xml` section, replace the strings inbetween the
     `<password>` tags with the password hash generated in step 7.
 12. Click **Save** to apply the changes.
+13. Go back to **Workloads** > **Pods** and select the {{< resource type="pod" name="mqttbroker" >}} Pod.
+14. {{< include "pod-delete" >}}
 
 <!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/enable-rbac-mqtt-broker.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/enable-rbac-mqtt-broker.md
@@ -61,6 +61,12 @@ Now all MQTT connections require password authentication with the following defa
 10. Click the **Edit** button to open the ConfigMap editor.
 11. In the `data.credentials.xml` section, replace the strings inbetween the
     `<password>` tags with the password hash generated in step 7.
+
+    {{< notice tip >}}
+    You can use a different password for each different microservice. Just
+    remember that you will need to update the configuration in each one
+    to use the new password.
+    {{< /notice >}}
 12. Click **Save** to apply the changes.
 13. Go back to **Workloads** > **Pods** and select the {{< resource type="pod" name="mqttbroker" >}} Pod.
 14. {{< include "pod-delete" >}}


### PR DESCRIPTION
# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
     Remember to also add relevant labels. -->
This PR adds an additional step to enable RBAC for the MQTT broker: after changing the credentials in the ConfigMap, one needs to recreate the Pod in order for the changes to take effect

## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

<!-- Enter here any additional information that might be useful -->
