### PR TITLE
Documentation corrections for Access Services from Outside Cluster

### DIFF
--- a/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
@@ -79,7 +79,7 @@ Follow these steps to access the Kafka Broker outside the cluster:
 
 4. Click **Save** to apply the changes.
 
-Access the Kafka Broker at at port 9094.
+Access the Kafka Broker at port 9094.
 
 ## Services with ClusterIP
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
@@ -45,21 +45,43 @@ service by default:
 - [Database](/docs/architecture/microservices/core/database/) at port 5432
 - [Kafka Console](/docs/architecture/microservices/core/kafka-console/) at port
   8090
-- [Kafka Broker](/docs/architecture/microservices/core/kafka-broker/) at port
-  9094
 - [Grafana](/docs/architecture/microservices/core/grafana/) at port 8080
 - [MQTT Broker](/docs/architecture/microservices/core/mqtt-broker/) at port
   1883
-- [Node-RED](/docs/architecture/microservices/core/node-red/) at port 1880
 - [OPCUA Simulator](/docs/architecture/microservices/community/opcua-simulator/)
   at port 46010
+- [Node-RED](/docs/architecture/microservices/core/node-red/) at port 1880
 
 {{% notice tip %}}
-To access Node-RED, you need to use the `/node-red` path, e.g.
+To access Node-RED, you need to use the `/node-red` path, for example
 `http://192.168.1.100:1880/node-red`.
 {{% /notice %}}
 
-## Services without a LoadBalancer
+## Services with NodePort by default
+
+The [Kafka Broker](/docs/architecture/microservices/core/kafka-broker/) uses the service type NodePort by default. 
+
+Follow these steps to access the Kafka Broker outside the cluster:
+
+1. Open UMHLens / OpenLens and navigate to **Network > Services**.
+2. Select the Service `united-manufacturing-hub-kafka-external` and click the **Edit** button.
+3. Scroll down to the line that shows:
+
+   ```yaml
+     type: NodePort
+   ```
+
+   Replace this with:
+
+   ```yaml
+     type: LoadBalancer
+   ```
+
+4. Click **Save** to apply the changes.
+
+Access the Kafka Broker at at port 9094.
+
+## Services with ClusterIP
 
 Some of the microservices in the United Manufacturing Hub are exposed via
 a ClusterIP service. That means that they are only accessible from within the
@@ -162,3 +184,5 @@ the section `spec.ports.port` to a different port number.
 
 <!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}
+
+- See how to [Expose Grafana to the Internet](/docs/production-guide/administration/expose-grafana-to-internet/)


### PR DESCRIPTION
# Description

Addresses a documentation issue where the process for accessing Kafka externally was not accurately described. 

Other minor edits include:

- Re-ordering the list of services for clarity, so Node-Red appears directly before the related tip
- Replaced e.g. with for example (per [style guide](https://umh.docs.umh.app/docs/development/contribute/documentation/style/style-guide/#avoid-latin-phrases))
- Added an item to the What's Next section (previously there was a heading for this section, but no items)

## Related issues

Fixes #150 

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

See the [Discord thread](https://discord.com/channels/700613971941785680/1141775447026323598).
