### PR TITLE
fix typo in Node-RED service path

### DIFF
--- a/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/administration/access-services-from-outside-cluster.md
@@ -53,8 +53,8 @@ service by default:
 - [Node-RED](/docs/architecture/microservices/core/node-red/) at port 1880
 
 {{% notice tip %}}
-To access Node-RED, you need to use the `/node-red` path, for example
-`http://192.168.1.100:1880/node-red`.
+To access Node-RED, you need to use the `/nodered` path, for example
+`http://192.168.1.100:1880/nodered`.
 {{% /notice %}}
 
 ## Services with NodePort by default


### PR DESCRIPTION
# Description

The URL in to access the Node-RED service should not have a hyphen, i.e. "nodered" and not "node-red".

## Checklist

- [X] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [X] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

