### PR TITLE
Delete hugo "print" output type from section

### DIFF
--- a/umh.docs.umh.app/hugo.toml
+++ b/umh.docs.umh.app/hugo.toml
@@ -35,7 +35,7 @@ style = "autumn"
 min = "v0.95.0"
 
 [outputs]
-section = ["HTML", "print"]
+section = ["HTML"]
 
 # Configure how URLs look like per section.
 [permalinks]


### PR DESCRIPTION
# Description

I'm trying to set up the local environment by following the steps in [this guide](https://umh.docs.umh.app/docs/development/contribute/documentation/setup-environment/).

It works until step:

```
cd <path_to_your_repo>/umh.docs.umh.app
hugo server --buildFuture
```

Which results in the error:

```
Error: command error: failed to create config: unknown output format "print" for kind "section"
```

The hugo.toml file contains a "print" Hugo output type under the `section` output. It's not mentioned in the [list of Hugo output formats](https://gohugo.io/templates/output-formats/). If it's something custom I think it needs additional configuration.


## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [X] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [X] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

Removing the "print" entry fixes this particular issue. However, the build fails because some components are missing:

```
Error: error building site: assemble: "/home/denis/code/umh.docs.umh.app/umh.docs.umh.app/content/en/docs/architecture/microservices/community/tulip-connector.md:32:1": failed to extract shortcode: template for shortcode "swaggerui" not found
```

I will not include this error because I think this topic warrants a separate PR if it's an actual problem.
