### PR TITLE
Fix git lfs in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@
 
 tasks:
   - init: | 
-      git config lfs.storage .git/lfs && git config lfs.https://github.com/united-manufacturing-hub/umh.docs.umh.app.git/info/lfs.locksverify false
+      git lfs pull
       make install
     command: |
       make serve

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,8 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - init: | 
+  - name: Install & Serve
+    init: | 
       git lfs pull
       make install
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,14 +5,11 @@
 # Learn more from ready-to-use templates: https://www.gitpod.io/docs/introduction/getting-started/quickstart
 
 tasks:
-  - before: |
-      git config lfs.storage .git/lfs && git config lfs.https://github.com/united-manufacturing-hub/umh.docs.umh.app.git/info/lfs.locksverify false
   - init: | 
+      git config lfs.storage .git/lfs && git config lfs.https://github.com/united-manufacturing-hub/umh.docs.umh.app.git/info/lfs.locksverify false
       make install
-      gp sync-done hugo-install
-  - command: |
-      gp sync-await hugo-install
-      make install && make serve
+    command: |
+      make serve
 
 # Ports to expose on workspace startup
 ports:

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,8 @@ install_postcss:
 install_submodules:
 	@git submodule update -f --init --recursive
 
-install_git_lfs:
-	# Installing dependencies for cloudflare
-	@(sudo apt-get install -y git-lfs && sudo git lfs install && sudo git lfs pull) || (git lfs install);
-	
 # Master install target
-install: check_versions install_submodules install_docsy install_postcss install_git_lfs
+install: check_versions install_submodules install_docsy install_postcss
 	@echo "All dependencies installed."
 
 # Serve the Hugo site

--- a/umh.docs.umh.app/static/images/lens-deployment-delete.jpg
+++ b/umh.docs.umh.app/static/images/lens-deployment-delete.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a6c70830a5db2ca6962ac1d5a7f04aea818f6fad503e010a50e4286f224bde6
+size 13965

--- a/umh.docs.umh.app/static/images/lens-deployment-delete.jpg
+++ b/umh.docs.umh.app/static/images/lens-deployment-delete.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a6c70830a5db2ca6962ac1d5a7f04aea818f6fad503e010a50e4286f224bde6
-size 13965


### PR DESCRIPTION
# Description

This PR fixes a permission issue with Git LFS that prevented to work with images in git as the normal user, always requiring sudo privileges.

GitPod already comes with Git LFS pre-installed, so there is no need to install it again. Also, the `git config` commands were unnecessary. Removing the `gp sync` commands is not a problem, since now there is only one task that executes the commands at the `init` step and then the `command` step, as opposed to having two different tasks that ran in parallel

## Related issues

Fix https://github.com/united-manufacturing-hub/MgmtIssues/issues/1052

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

