### PR TITLE
Revise backup recovery database page

### DIFF
--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -89,7 +89,8 @@ definitions, as well as information on sequences, owners, and settings:
 
    The default password is `changeme`.
 
-4. Check the table list running `\dt` and run the following command for each table to save all data to `.csv` files:
+4. Check the table list running `\dt` and run the following command for each table 
+to save all data to `.csv` files:
 
    ```sql
    \COPY (SELECT * FROM <TABLE_NAME>) TO <TABLE_NAME>.csv CSV
@@ -191,7 +192,8 @@ with the following command:
    \COPY <table-name> FROM '<table-name>.csv' WITH (FORMAT CSV);
    ```
 
-6. Go back to the terminal connected to the server and take the database out of maintenance mode. Make sure that the databsae shell is open:
+6. Go back to the terminal connected to the server and take the database out of 
+maintenance mode. Make sure that the databsae shell is open:
 
    ```sql
    SELECT timescaledb_post_restore();

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -114,13 +114,17 @@ The default username for `umh_v2` database is `kafkatopostgresqlv2`, and the pas
 For this section, we assume that you are restoring the data to a fresh United
 Manufacturing Hub installation with an empty database.
 
-### Temporarly disable kafkatopostrgesql
+### Temporarly disable kafkatopostrgesql, kafkatopostgresqlv2, and factoryinsight
 
-Connect to your server via SSH and run the following command: 
+Since `kafkatopostrgesql`, `kafkatopostgresqlv2`, and `factoryinsight` microservices 
+might write actual data into the database while restoring it, they should be 
+disabled. Connect to your server via SSH and run the following command: 
 
 <!-- tested in e2e #1343 -->
 ```bash
-sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresql" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresql" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml;
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresqlv2" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml;
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="factoryinsight" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
 ```
 
 ### Restore the database
@@ -138,7 +142,7 @@ For `umh_v2`, you should use `kafkatopostgresqlv2` for the user name and
 2. Drop the existing database:
 
    ```sql
-   DROP DATABASE factoryinsight WITH (FORCE);
+   DROP DATABASE factoryinsight;
    ```
 
 3. Create a new database:
@@ -186,7 +190,7 @@ with the following command:
       ```
    - Grafana database does not have hypertables by default.
 
-8. Run the follwoing SQL commands for each table to restore data into database:
+8. Run the following SQL commands for each table to restore data into database:
 
    ```sql
    \COPY <table-name> FROM '<table-name>.csv' WITH (FORMAT CSV);
@@ -199,13 +203,15 @@ maintenance mode. Make sure that the databsae shell is open:
    SELECT timescaledb_post_restore();
    ```
 
-### Enable kafkatopostgresql
+### Enable kafkatopostgresql, kafkatopostgresqlv2, and factoryinsight
 
-Run the following command to enable `kafkatopostgresql`:
+Run the following command to enable `kafkatopostgresql`, `kafkatopostgresqlv2`, and `factoryinsight`:
 
 <!-- tested in e2e #1343 -->
 ```bash
-sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresql" >}} --replicas=1 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresql" >}} --replicas=1 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml;
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafkatopostgresqlv2" >}} --replicas=1 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml;
+sudo $(which kubectl) scale deployment {{< resource type="deployment" name="factoryinsight" >}} --replicas=2 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
 ```
 
 <!-- Optional section; add links to information related to this topic. -->

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -71,6 +71,8 @@ definitions, as well as information on sequences, owners, and settings:
    pg_dump -U factoryinsight -h <remote-host> -p 5432 -Fc -v --section=pre-data --exclude-schema="_timescaledb*" -f dump_pre_data.bak factoryinsight
    ```
 
+   Then, enter your password. The default for factoryinsight is `changeme`.
+
    - `<remote-host>` is the server's IP where the database (UMH instance) is running.
 
    {{% notice note %}}
@@ -85,7 +87,7 @@ definitions, as well as information on sequences, owners, and settings:
    psql "postgres://factoryinsight:<password>@<server-IP>:5432/factoryinsight?sslmode=require"
    ```
 
-   The default username for factoryinsight is `factoryinsight` and the password is `changeme`.
+   The default password is `changeme`.
 
 4. Check the table list running `\dt` and run the following command for each table to save all data to `.csv` files:
 
@@ -102,8 +104,8 @@ In addition, you need to write down the credentials in the
 {{< resource type="secret" name="grafana" >}} Secret, as they are necessary
 to access the dashboard after restoring the database.
 
-The default username for umh_v2 is `kafkatopostgresqlv2`, and the password is 
-`changemetoo`.
+The default username for `umh_v2` database is `kafkatopostgresqlv2`, and the password is 
+`changemetoo`. 
 
 ## Restoring the database
 
@@ -113,7 +115,7 @@ Manufacturing Hub installation with an empty database.
 
 ### Temporarly disable kafkatopostrgesql
 
-Run the following command: 
+Connect to your server via SSH and run the following command: 
 
 <!-- tested in e2e #1343 -->
 ```bash
@@ -123,10 +125,12 @@ sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafk
 ### Restore the database
 
 This section shows an example for restoring factoryinsight. If you want to restore 
-`umh_v2` or `grafana`, you need to replace any occurence of `factoryinsight` with 
-`umh_v2` or `grafana`.
+`grafana`, you need to replace any occurence of `factoryinsight` with `grafana`.
 
-1. Connect to your server via SSH and run the following command:
+For `umh_v2`, you should use `kafkatopostgresqlv2` for the user name and 
+`changemetoo` for the password.
+
+1. Make sure that your device is connected to server via SSH and run the following command:
 
    {{< include "open-database-shell" >}}
 
@@ -184,10 +188,10 @@ with the following command:
 8. Run the follwoing SQL commands for each table to restore data into database:
 
    ```sql
-   \copy <table-name> FROM '<table-name>.csv' WITH (FORMAT CSV);
+   \COPY <table-name> FROM '<table-name>.csv' WITH (FORMAT CSV);
    ```
 
-6. Take the database out of maintenance mode:
+6. Go back to the terminal connected to the server and take the database out of maintenance mode. Make sure that the databsae shell is open:
 
    ```sql
    SELECT timescaledb_post_restore();

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -103,13 +103,10 @@ Manufacturing Hub installation with an empty database.
 
 ### Copy the backup file to the database pod
 
-1. Open {{< resource type="lens" name="name" >}}.
-2. Launch a new terminal sesstion by clicking on the **+** button in the
-   bottom-left corner of the window.
-3. Run the following command to copy the backup file to the database pod:
+1. Run the following command to copy the backup file to the database pod:
 
    ```bash
-   kubectl cp /path/to/local/backup.bak {{< resource type="pod" name="database" >}}:/tmp/backup.bak
+   sudo $(which kubectl) cp <path-to-local>/backup.bak {{< resource type="pod" name="database" >}}:/tmp/backup.bak -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
    ```
 
    Replace `/path/to/local/backup.bak` with the path to the backup file on your

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -67,20 +67,12 @@ machine:
 2. Run the following command:
 
    ```bash
-   pg_dump -h <REMOTE_HOST> -p 5432 -U factoryinsight -Fc -f <BACKUP_NAME>.bak 
-   factoryinsight
+   pg_dump -h <REMOTE_HOST> -p 5432 -U factoryinsight -Fc -f <BACKUP_NAME>.bak factoryinsight
    ```
 
    - `<REMOTE_HOST>` is the IP of the server where the database is running.
      Use `localhost` if you installed the United Manufacturing Hub using k3d.
    - `<BACKUP_NAME>` is the name of the backup file.
-
-3. Using `scp` (secure copy), save the `.bak` file on the server. If you use 
-Windows OS, you need to install it.
-
-   ```bash
-   scp <source-file-on-local-machine> <save-destination-on-server>
-   ```
 
 ### Grafana database
 
@@ -94,23 +86,33 @@ to access the dashboard after restoring the database.
 
 ## Restoring the database
 
-{{< notice warning >}}
-This section is untested. Please report any issues you encounter.
-{{< /notice >}}
+{{% notice warning %}}
+
+This method works best on databases smaller than 100 GB. You can find more detailed 
+information in [the official documentation of TimescaleDB](https://docs.timescale.com/self-hosted/latest/migration/entire-database/). 
+Also, refer [this documentation](https://docs.timescale.com/self-hosted/latest/migration/entire-database/) 
+for larger databases to migrate schema and data separately or to restore your 
+hypertables.
+
+{{% /notice %}}
 
 For this section, we assume that you are restoring the data to a fresh United
 Manufacturing Hub installation with an empty database.
 
 ### Copy the backup file to the database pod
 
-1. Run the following command to copy the backup file to the database pod:
+1. Using `scp` (secure copy), save the `.bak` file on the server. If you use 
+Windows OS, you need to install it. Run the following command on your local machine:
 
    ```bash
-   sudo $(which kubectl) cp <path-to-local>/backup.bak {{< resource type="pod" name="database" >}}:/tmp/backup.bak -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
+   scp <path-to-local-.bak-file> <umh-instance-ip>:<save-location-on-server>
    ```
 
-   Replace `/path/to/local/backup.bak` with the path to the backup file on your
-   machine.
+2. Run the following command to copy the backup file to the database pod (on the server):
+
+   ```bash
+   sudo $(which kubectl) cp <path-to-host-.bak-file> {{< resource type="pod" name="database" >}}:/tmp/backup.bak -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
+   ```
 
 This step could take a while depending on the size of the backup file.
 
@@ -169,5 +171,5 @@ sudo $(which kubectl) scale deployment {{< resource type="deployment" name="kafk
 <!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}
 
-- See the official [TimescaleDB backup guide](https://docs.timescale.com/timescaledb/latest/how-to-guides/backup-and-restore/pg-dump-and-restore/)
+- See the official [TimescaleDB migration guide](https://docs.timescale.com/self-hosted/latest/migration/entire-database/)
 - See the official [pg_dump documentation](https://www.postgresql.org/docs/current/app-pgdump.html)

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -13,10 +13,10 @@ aliases:
 ## {{% heading "prerequisites" %}}
 
 For this task, you need to have [PostgreSQL](https://www.postgresql.org/download/)
-installed on your machine. Make sure that its version is a compatible with the version
+installed on your machine. Make sure that its version is compatible with the version
 installed on the UMH.
 
-You also need to have enough space on your machine to store the backup. To check
+Also, enough free space is required on your machine to store the backup. To check
 the size of the database, ssh into the system and follow the steps below:
 
 {{< include "open-database-shell" >}}
@@ -64,13 +64,14 @@ machine:
    If the folder does not exist, you can create it using the `mkdir` command or
    your file manager.
 
-2. Run the following command to dump the schema pre-data. :
+2. Run the following command to backup pre-data, which includes table and schema 
+definitions, as well as information on sequences, owners, and settings:
 
    ```bash
    pg_dump -U factoryinsight -h <remote-host> -p 5432 -Fc -v --section=pre-data --exclude-schema="_timescaledb*" -f dump_pre_data.bak factoryinsight
    ```
 
-   - `<remote-host>` is the IP of the server where the database (UMH instance) is running.
+   - `<remote-host>` is the server's IP where the database (UMH instance) is running.
 
    {{% notice note %}}
 
@@ -97,11 +98,12 @@ machine:
 If you want to backup the Grafana or umh_v2 database, you can follow the same steps 
 as above, but you need to replace any occurence of `factoryinsight` with `grafana`.
 
-Additionally, you also need to write down the credentials in the
-{{< resource type="secret" name="grafana" >}} Secret, as they will be needed
+In addition, you need to write down the credentials in the
+{{< resource type="secret" name="grafana" >}} Secret, as they are necessary
 to access the dashboard after restoring the database.
 
-The default username for umh_v2 is `kafkatopostgresqlv2` and the password is `changemetoo`.
+The default username for umh_v2 is `kafkatopostgresqlv2`, and the password is 
+`changemetoo`.
 
 ## Restoring the database
 
@@ -111,7 +113,7 @@ Manufacturing Hub installation with an empty database.
 
 ### Temporarly disable kafkatopostrgesql
 
-Run the following command to disable `kafkatopostgresql` temporarly: 
+Run the following command: 
 
 <!-- tested in e2e #1343 -->
 ```bash

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-database.md
@@ -13,7 +13,8 @@ aliases:
 ## {{% heading "prerequisites" %}}
 
 For this task, you need to have [PostgreSQL](https://www.postgresql.org/download/)
-installed on your machine.
+installed on your machine. Make sure that its version is a compatible with the version
+installed on the UMH.
 
 You also need to have enough space on your machine to store the backup. To check
 the size of the database, ssh into the system and follow the steps below:
@@ -30,6 +31,12 @@ Connect to the `umh_v2` or `factoryinsight` database:
 
 ```sql
 SELECT pg_size_pretty(pg_database_size('<database-name>'));
+```
+
+If you need, check the version of PostgreSQL with this command:
+
+```bash
+\! psql --version
 ```
 
 <!-- steps -->
@@ -60,12 +67,20 @@ machine:
 2. Run the following command:
 
    ```bash
-   pg_dump -h <REMOTE_HOST> -p 5432 -U factoryinsight -Fc -f <BACKUP_NAME>.bak factoryinsight
+   pg_dump -h <REMOTE_HOST> -p 5432 -U factoryinsight -Fc -f <BACKUP_NAME>.bak 
+   factoryinsight
    ```
 
    - `<REMOTE_HOST>` is the IP of the server where the database is running.
      Use `localhost` if you installed the United Manufacturing Hub using k3d.
    - `<BACKUP_NAME>` is the name of the backup file.
+
+3. Using `scp` (secure copy), save the `.bak` file on the server. If you use 
+Windows OS, you need to install it.
+
+   ```bash
+   scp <source-file-on-local-machine> <save-destination-on-server>
+   ```
 
 ### Grafana database
 


### PR DESCRIPTION
# Description

- The process for backup and restore is updated and tested. (The old instruction do not consider hypertables.)
- For `umh_v2`, it mentions which username, password should be used instead of `factoryinsight`.
- This guide is used: https://docs.timescale.com/self-hosted/latest/migration/schema-then-data/

## Related issues

close united-manufacturing-hub/MgmtIssues/issues/1338

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

