### PR TITLE
Revise page: backup restore umh

### DIFF
--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -73,13 +73,19 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="ka
 sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mqttbroker" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
 ```
 
-### Copy kubeconfig file (for flatcar)
+### Copy kubeconfig file
 
 1. Move to the folder on the server where the kubeconfig file is located:
 
    ```bash
    cd /etc/rancher/k3s
    ```
+
+   {{% notice tip %}}
+   This guide assumes that the kubeconfig file is located at 
+   `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
+   environment and may differ.
+   {{% /notice %}}
 
 2. Show the content of `k3s.yaml` with the following command and copy the output:
 
@@ -107,13 +113,13 @@ The backup script is located inside the folder you downloaded earlier.
 1. Open a terminal and navigate inside the folder.
 
    ```powershell
-   cd <folder-path>
+   cd <FOLDER_PATH>
    ```
 
 2. Run the script:
 
    ```powershell
-   .\backup.ps1 -IP <ip-of-the-server> -GrafanaToken <grafana-api-key> -KubeconfigPath <path-to-kubeconfig-saved-locally>
+   .\backup.ps1 -IP <IP_OF_THE_SERVER> -GrafanaToken <GRAFANA_API_KEY> -KubeconfigPath <PATH_TO_KUBECONFIG_SAVED_LOCALLY>
    ```
 
    You can find a list of all available parameters down below.

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -12,7 +12,8 @@ This page describes how to back up the following:
 - All Node-RED flows
 - All Grafana dashboards
 - The Helm values used for installing the {{< resource type="helm" name="release" >}} release
-- All the contents of the United Manufacturing Hub database
+- All the contents of the United Manufacturing Hub database (`factoryinsight` and `umh_v2`)
+- The Management Console Companion's setting
 
 It does **not** back up:
 - Additional databases other than the United Manufacturing Hub default database

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -250,6 +250,10 @@ following parameters:
   {{< /tab >}}
 {{< /tabs >}}
 
+You can check the database password by running the following command in your instance's shell:
+```bash
+sudo $(which kubectl) get secret united-manufacturing-hub-credentials --kubeconfig /etc/rancher/k3s/k3s.yaml -n united-manufacturing-hub -o jsonpath="{.data.PATRONI_SUPERUSER_PASSWORD}" | base64 --decode; echo
+```
 
 ### Restore the Management Console Companion
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -236,7 +236,7 @@ the following parameters:
       ```
 
 2. Execute the `.\restore-timescale.ps1` and  `.\restore-timescale-v2.ps1` script with the
-following parameters:
+following parameters to restore `factoryinsight` and `umh_v2` databases:
       ```powershell
       .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
       .\restore-timescale-v2.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -37,27 +37,11 @@ the size of the database, ssh into the system and follow the steps below:
 
 {{< include "open-database-shell" >}}
 
-Connect to the `umh_v2` or `factoryinsight` database:
-
-{{< tabs name="connect_db" >}}
-  {{< tab name="factoryinsight" codelang="sql" >}}
-  \c factoryinsight
-  {{< /tab >}}
-  {{< tab name="umh_v2" codelang="sql" >}}
-  \c umh_v2
-  {{< /tab >}}
-  {{< /tabs >}}
-
  Run the following command to get the size of the database:
 
-{{< tabs name="get_size_db" >}}
-  {{< tab name="factoryinsight" codelang="sql" >}}
-  SELECT pg_size_pretty(pg_database_size('factoryinsight'));
-  {{< /tab >}}
-  {{< tab name="umh_v2" codelang="sql" >}}
-  SELECT pg_size_pretty(pg_database_size('umh_v2'));
-  {{< /tab >}}
-  {{< /tabs >}}
+```sql
+SELECT pg_size_pretty(pg_database_size('umh_v2')) AS "umh_v2", pg_size_pretty(pg_database_size('factoryinsight')) AS "factoryinsight";
+```
 
 <!-- steps -->
 ## Backup
@@ -86,21 +70,34 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mq
 
 ### Copy kubeconfig file
 
-1. Show the content of kubeconfig file with the following command and copy the output:
+The backup script is located inside the folder you downloaded earlier.
 
-   ```bash
-   sudo cat /etc/rancher/k3s/k3s.yaml
-   ```
+1. Open a terminal and navigate inside the folder.
 
-   {{% notice tip %}}
-   This guide assumes that the kubeconfig file is located at 
-   `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
-   environment and may differ.
-   {{% /notice %}}
+      ```powershell
+      cd <FOLDER_PATH>
+      ```
 
-2. Create a `.yaml` file on your local device and paste the content in it.
+2. Create a file with the name `k3s.yaml` on your local device.
 
-3. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+      ```powershell
+      cd > k3s.yaml
+      ```
+
+3. Show the content of kubeconfig file with the following command in 
+the instance's shell and copy&paste the output to `k3s.yaml` on your device:
+
+      ```bash
+      sudo cat /etc/rancher/k3s/k3s.yaml
+      ```
+
+      {{% notice tip %}}
+      This guide assumes that the kubeconfig file is located at 
+      `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
+      environment and may differ.
+      {{% /notice %}}
+
+4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
 then save it:
       ```yaml
       apiVersion: v1
@@ -124,7 +121,7 @@ The backup script is located inside the folder you downloaded earlier.
 2. Run the script:
 
    ```powershell
-   .\backup.ps1 -IP <IP_OF_THE_SERVER> -GrafanaToken <GRAFANA_API_KEY> -KubeconfigPath <PATH_TO_KUBECONFIG_SAVED_LOCALLY>
+   .\backup.ps1 -IP <IP_OF_THE_SERVER> -GrafanaToken <GRAFANA_API_KEY> -KubeconfigPath .\k3s.yaml
    ```
 
    You can find a list of all available parameters down below.
@@ -172,21 +169,35 @@ failure.
 
 ### Copy kubeconfig file
 
-1. Show the content of kubeconfig file with the following command and copy the output:
+The backup script is located inside the folder you downloaded earlier.
 
-   ```bash
-   sudo cat /etc/rancher/k3s/k3s.yaml
-   ```
+1. Open a terminal and navigate inside the folder.
 
-   {{% notice tip %}}
-   This guide assumes that the kubeconfig file is located at 
-   `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
-   environment and may differ.
-   {{% /notice %}}
+      ```powershell
+      cd <FOLDER_PATH>
+      ```
 
-2. Create a `.yaml` file on your local device and paste the content in it.
+2. Create a file with the name `k3s.yaml` on your local device, 
+if it does not exist in the backup scripts' folder.
 
-3. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+      ```powershell
+      cd > k3s.yaml
+      ```
+
+3. Show the content of kubeconfig file with the following command in 
+the instance's shell and copy&paste the output to `k3s.yaml` on your device:
+
+      ```bash
+      sudo cat /etc/rancher/k3s/k3s.yaml
+      ```
+
+      {{% notice tip %}}
+      This guide assumes that the kubeconfig file is located at 
+      `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
+      environment and may differ.
+      {{% /notice %}}
+
+4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
 then save it:
       ```yaml
       apiVersion: v1
@@ -202,7 +213,7 @@ To restore the Kubernetes cluster, execute the `.\restore-helm.ps1` script with
 the following parameters:
 
 ```powershell
-.\restore-helm.ps1 -KubeconfigPath <PATH_TO_KUBECONFIG> -BackupPath <PATH_TO_BACKUP_FOLDER>
+.\restore-helm.ps1 -KubeconfigPath .\k3s.yaml -BackupPath <PATH_TO_BACKUP_FOLDER>
 ```
 
 Verify that the cluster is up and running by opening {{< resource type="lens" name="name" >}}
@@ -233,7 +244,7 @@ To restore the Node-RED flows, execute the `.\restore-nodered.ps1` script with
 the following parameters:
 
    ````powershell
-   .\restore-nodered.ps1 -KubeconfigPath <PATH_TO_KUBECONFIG> -BackupPath <PATH_TO_BACKUP_FOLDER>
+   .\restore-nodered.ps1 -KubeconfigPath .\k3s.yaml -BackupPath <PATH_TO_BACKUP_FOLDER>
    ````
 
 ### Restore the database
@@ -259,7 +270,7 @@ sudo $(which kubectl) get secret united-manufacturing-hub-credentials --kubeconf
 
 Execute the `.\restore-companion.ps1` script with the following parameters to restore the companion:
    ```powershell
-   .\restore-companion.ps1 -KubeconfigPath <PATH_TO_KUBECONFIG_OF_THE_NEW_SERVER> -BackupPath <FULL_PATH_TO_BACKUP_FOLDER>
+   .\restore-companion.ps1 -KubeconfigPath .\k3s.yaml -BackupPath <FULL_PATH_TO_BACKUP_FOLDER>
    ```
 
 ## Troubleshooting

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -70,43 +70,34 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mq
 
 ### Copy kubeconfig file
 
-The backup script is located inside the folder you downloaded earlier.
+To run the backup script, you'll first need to obtain a copy of the Kubernetes 
+configuration file from your instance. This is essential for providing the 
+script with access to the instance.
 
-1. Open a terminal and navigate inside the folder.
+1. In the shell of your instance, execute the following command to display the 
+Kubernetes configuration:
 
-      ```powershell
-      cd <FOLDER_PATH>
-      ```
+   ```bash
+   sudo cat /etc/rancher/k3s/k3s.yaml
+   ```
 
-2. Create a file with the name `k3s.yaml` on your local device.
+   Make sure to copy the entire output to your clipboard.
 
-      ```powershell
-      cd > k3s.yaml
-      ```
+   {{% notice tip %}}
+   This tutorial is based on the assumption that your kubeconfig file is located 
+   at /etc/rancher/k3s/k3s.yaml. Depending on your setup, the actual file location 
+   might be different.
+   {{% /notice %}}
 
-3. Show the content of kubeconfig file with the following command in 
-the instance's shell and copy&paste the output to `k3s.yaml` on your device:
+2. Open a text editor, like Notepad, on your local machine and paste the copied content.
+3. In the pasted content, find the server field. It usually defaults to `https://127.0.0.1:6443`. 
+Replace this with your instance's IP address
 
-      ```bash
-      sudo cat /etc/rancher/k3s/k3s.yaml
-      ```
+    ```yaml
+    server: https://<INSTANCE_IP>:6443
+    ```
 
-      {{% notice tip %}}
-      This guide assumes that the kubeconfig file is located at 
-      `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
-      environment and may differ.
-      {{% /notice %}}
-
-4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
-then save it:
-      ```yaml
-      apiVersion: v1
-      clusters:
-      - cluster:
-         certificate-authority-data: xxx
-         server: https://<your-server-ip>:6443
-      
-      ```
+4. Save the file as `k3s.yaml` inside the `backup` folder you downloaded earlier.
 
 ### Backup using the script
 
@@ -169,44 +160,34 @@ failure.
 
 ### Copy kubeconfig file
 
-The backup script is located inside the folder you downloaded earlier.
+To run the backup script, you'll first need to obtain a copy of the Kubernetes 
+configuration file from your instance. This is essential for providing the 
+script with access to the instance.
 
-1. Open a terminal and navigate inside the folder.
+1. In the shell of your instance, execute the following command to display the 
+Kubernetes configuration:
 
-      ```powershell
-      cd <FOLDER_PATH>
-      ```
+   ```bash
+   sudo cat /etc/rancher/k3s/k3s.yaml
+   ```
 
-2. Create a file with the name `k3s.yaml` on your local device, 
-if it does not exist in the backup scripts' folder.
+   Make sure to copy the entire output to your clipboard.
 
-      ```powershell
-      cd > k3s.yaml
-      ```
+   {{% notice tip %}}
+   This tutorial is based on the assumption that your kubeconfig file is located 
+   at /etc/rancher/k3s/k3s.yaml. Depending on your setup, the actual file location 
+   might be different.
+   {{% /notice %}}
 
-3. Show the content of kubeconfig file with the following command in 
-the instance's shell and copy&paste the output to `k3s.yaml` on your device:
+2. Open a text editor, like Notepad, on your local machine and paste the copied content.
+3. In the pasted content, find the server field. It usually defaults to `https://127.0.0.1:6443`. 
+Replace this with your instance's IP address
 
-      ```bash
-      sudo cat /etc/rancher/k3s/k3s.yaml
-      ```
+    ```yaml
+    server: https://<INSTANCE_IP>:6443
+    ```
 
-      {{% notice tip %}}
-      This guide assumes that the kubeconfig file is located at 
-      `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
-      environment and may differ.
-      {{% /notice %}}
-
-4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
-then save it:
-      ```yaml
-      apiVersion: v1
-      clusters:
-      - cluster:
-         certificate-authority-data: xxx
-         server: https://<your-server-ip>:6443
-      
-      ```
+4. Save the file as `k3s.yaml` inside the `backup` folder you downloaded earlier.
 
 ### Cluster configuration
 To restore the Kubernetes cluster, execute the `.\restore-helm.ps1` script with
@@ -243,28 +224,23 @@ with the following parameters:
 To restore the Node-RED flows, execute the `.\restore-nodered.ps1` script with
 the following parameters:
 
-   ````powershell
+   ```powershell
    .\restore-nodered.ps1 -KubeconfigPath .\k3s.yaml -BackupPath <PATH_TO_BACKUP_FOLDER>
-   ````
+   ```
 
 ### Restore the database
 
-To restore the `factoryinsight` or `umh_v2` database, execute the `.\restore-timescale.ps1` or  `.\restore-timescale-v2.ps1` script with the
+1. Check the database password by running the following command in your instance's shell:
+      ```bash
+      sudo $(which kubectl) get secret united-manufacturing-hub-credentials --kubeconfig /etc/rancher/k3s/k3s.yaml -n united-manufacturing-hub -o jsonpath="{.data.PATRONI_SUPERUSER_PASSWORD}" | base64 --decode; echo
+      ```
+
+2. Execute the `.\restore-timescale.ps1` and  `.\restore-timescale-v2.ps1` script with the
 following parameters:
-
-{{< tabs name="restore_db" >}}
-  {{< tab name="factoryinsight" codelang="powershell" >}}
-  .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
-  {{< /tab >}}
-  {{< tab name="umh_v2" codelang="powershell" >}}
-  .\restore-timescale-v2.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
-  {{< /tab >}}
-{{< /tabs >}}
-
-You can check the database password by running the following command in your instance's shell:
-```bash
-sudo $(which kubectl) get secret united-manufacturing-hub-credentials --kubeconfig /etc/rancher/k3s/k3s.yaml -n united-manufacturing-hub -o jsonpath="{.data.PATRONI_SUPERUSER_PASSWORD}" | base64 --decode; echo
-```
+      ```powershell
+      .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
+      .\restore-timescale-v2.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
+      ```
 
 ### Restore the Management Console Companion
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -55,7 +55,7 @@ SELECT pg_size_pretty(pg_database_size('<database-name>'));
 
 Create a Grafana API Token for an admin user by following these steps:
 1. Open the Grafana UI in your browser and log in with an admin user.
-2. Click on the **Settings** icon in the left sidebar and select **API Keys**.
+2. Click on the **Configuration** icon in the left sidebar and select **API Keys**.
 3. Give the API key a name and change its role to **Admin**.
 4. Optionally set an expiration date.
 5. Click **Add**.
@@ -73,6 +73,32 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="ka
 sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mqttbroker" >}} --replicas=0 -n united-manufacturing-hub --kubeconfig /etc/rancher/k3s/k3s.yaml
 ```
 
+### Copy kubeconfig file (for flatcar)
+
+1. Move to the folder on the server where the kubeconfig file is located:
+
+   ```bash
+   cd /etc/rancher/k3s
+   ```
+
+2. Show the content of `k3s.yaml` with the following command and copy the output:
+
+   ```bash
+   sudo cat k3s.yaml
+   ```
+
+3. Create a `.yaml` file on your local device and paste the content in it.
+
+4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, then save it:
+      ```yaml
+      apiVersion: v1
+      clusters:
+      - cluster:
+         certificate-authority-data: xxx
+         server: https://<your-server-ip>:6443
+      
+      ```
+
 ### Backup using the script
 
 The backup script is located inside the folder you downloaded earlier.
@@ -86,7 +112,7 @@ The backup script is located inside the folder you downloaded earlier.
 2. Run the script:
 
    ```powershell
-   .\backup.ps1 -IP <IP_OF_THE_SERVER> -GrafanaToken <GRAFANA_API_KEY> -KubeconfigPath <PATH_TO_KUBECONFIG>
+   .\backup.ps1 -IP <ip-of-the-server> -GrafanaToken <grafana-api-key> -KubeconfigPath <path-to-kubeconfig-saved-locally>
    ```
 
    You can find a list of all available parameters down below.
@@ -148,7 +174,7 @@ To restore the Grafana dashboards, you first need to create a Grafana API Key
 for an admin user in the new cluster by following these steps:
 
 1. Open the Grafana UI in your browser and log in with an admin user.
-2. Click on the **Settings** icon in the left sidebar and select **API Keys**.
+2. Click on the **Configuration** icon in the left sidebar and select **API Keys**.
 3. Give the API key a name and change its role to **Admin**.
 4. Optionally set an expiration date.
 5. Click **Add**.

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -89,7 +89,8 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mq
 
 3. Create a `.yaml` file on your local device and paste the content in it.
 
-4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, then save it:
+4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+then save it:
       ```yaml
       apiVersion: v1
       clusters:
@@ -106,7 +107,7 @@ The backup script is located inside the folder you downloaded earlier.
 1. Open a terminal and navigate inside the folder.
 
    ```powershell
-   cd <FOLDER_PATH>
+   cd <folder-path>
    ```
 
 2. Run the script:
@@ -158,6 +159,33 @@ Each component of the United Manufacturing Hub can be restored separately, in
 order to allow for more flexibility and to reduce the damage in case of a
 failure.
 
+### Copy kubeconfig file (for flatcar)
+
+1. Move to the folder on the server where the kubeconfig file is located:
+
+   ```bash
+   cd /etc/rancher/k3s
+   ```
+
+2. Show the content of `k3s.yaml` with the following command and copy the output:
+
+   ```bash
+   sudo cat k3s.yaml
+   ```
+
+3. Create a `.yaml` file on your local device and paste the content in it.
+
+4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+then save it:
+      ```yaml
+      apiVersion: v1
+      clusters:
+      - cluster:
+         certificate-authority-data: xxx
+         server: https://<your-server-ip>:6443
+      
+      ```
+
 ### Cluster configuration
 To restore the Kubernetes cluster, execute the `.\restore-helm.ps1` script with
 the following parameters:
@@ -205,6 +233,19 @@ following parameters:
    ````powershell
    .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
    ````
+
+## Troubleshooting
+### Unable to connect to the server: x509: certificate signed ...
+This issue can occur when the device's IP address changes from DHCP to static 
+after installation. A quick solution is skipping TLS validation. If you want 
+to enable `insecure-skip-tls-verify` option, run the following command on 
+the instance's shell **before** copying kubeconfig on the server:
+
+   ```bash
+   sudo $(which kubectl) config set-cluster default --insecure-skip-tls-verify=true --kubeconfig /etc/rancher/k3s/k3s.yaml
+   ```
+
+
 
 <!-- Optional section; add links to information related to this topic. -->
 ## {{% heading "whatsnext" %}}

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -238,12 +238,25 @@ the following parameters:
 
 ### Restore the database
 
-To restore the database, execute the `.\restore-timescale.ps1` script with the
+To restore the `factoryinsight` or `umh_v2` database, execute the `.\restore-timescale.ps1` or  `.\restore-timescale-v2.ps1` script with the
 following parameters:
 
-   ````powershell
-   .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
-   ````
+{{< tabs name="restore_db" >}}
+  {{< tab name="factoryinsight" codelang="powershell" >}}
+  .\restore-timescale.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
+  {{< /tab >}}
+  {{< tab name="umh_v2" codelang="powershell" >}}
+  .\restore-timescale-v2.ps1 -Ip <IP_OF_THE_SERVER> -BackupPath <PATH_TO_BACKUP_FOLDER> -PatroniSuperUserPassword <DATABASE_PASSWORD>
+  {{< /tab >}}
+{{< /tabs >}}
+
+
+### Restore the Management Console Companion
+
+Execute the `.\restore-companion.ps1` script with the following parameters to restore the companion:
+   ```powershell
+   .\restore-companion.ps1 -KubeconfigPath <PATH_TO_KUBECONFIG_OF_THE_NEW_SERVER> -BackupPath <FULL_PATH_TO_BACKUP_FOLDER>
+   ```
 
 ## Troubleshooting
 ### Unable to connect to the server: x509: certificate signed ...

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -13,7 +13,7 @@ This page describes how to back up the following:
 - All Grafana dashboards
 - The Helm values used for installing the {{< resource type="helm" name="release" >}} release
 - All the contents of the United Manufacturing Hub database (`factoryinsight` and `umh_v2`)
-- The Management Console Companion's setting
+- The Management Console Companion's settings
 
 It does **not** back up:
 - Additional databases other than the United Manufacturing Hub default database
@@ -264,7 +264,7 @@ Execute the `.\restore-companion.ps1` script with the following parameters to re
 
 ## Troubleshooting
 ### Unable to connect to the server: x509: certificate signed ...
-This issue can occur when the device's IP address changes from DHCP to static 
+This issue may occur when the device's IP address changes from DHCP to static 
 after installation. A quick solution is skipping TLS validation. If you want 
 to enable `insecure-skip-tls-verify` option, run the following command on 
 the instance's shell **before** copying kubeconfig on the server:

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -38,15 +38,25 @@ the size of the database, ssh into the system and follow the steps below:
 
 Connect to the `umh_v2` or `factoryinsight` database:
 
-```bash
-\c <database-name>
-```
+{{< tabs name="connect_db" >}}
+  {{< tab name="factoryinsight" codelang="sql" >}}
+  \c factoryinsight
+  {{< /tab >}}
+  {{< tab name="umh_v2" codelang="sql" >}}
+  \c umh_v2
+  {{< /tab >}}
+  {{< /tabs >}}
 
  Run the following command to get the size of the database:
 
-```sql
-SELECT pg_size_pretty(pg_database_size('<database-name>'));
-```
+{{< tabs name="get_size_db" >}}
+  {{< tab name="factoryinsight" codelang="sql" >}}
+  SELECT pg_size_pretty(pg_database_size('factoryinsight'));
+  {{< /tab >}}
+  {{< tab name="umh_v2" codelang="sql" >}}
+  SELECT pg_size_pretty(pg_database_size('umh_v2'));
+  {{< /tab >}}
+  {{< /tabs >}}
 
 <!-- steps -->
 ## Backup

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -165,13 +165,19 @@ Each component of the United Manufacturing Hub can be restored separately, in
 order to allow for more flexibility and to reduce the damage in case of a
 failure.
 
-### Copy kubeconfig file (for flatcar)
+### Copy kubeconfig file
 
 1. Move to the folder on the server where the kubeconfig file is located:
 
    ```bash
    cd /etc/rancher/k3s
    ```
+
+   {{% notice tip %}}
+   This guide assumes that the kubeconfig file is located at 
+   `/etc/rancher/k3s/k3s.yaml`. The location depends on your 
+   environment and may differ.
+   {{% /notice %}}
 
 2. Show the content of `k3s.yaml` with the following command and copy the output:
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/backup_recovery/backup-restore-umh.md
@@ -75,10 +75,10 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mq
 
 ### Copy kubeconfig file
 
-1. Move to the folder on the server where the kubeconfig file is located:
+1. Show the content of kubeconfig file with the following command and copy the output:
 
    ```bash
-   cd /etc/rancher/k3s
+   sudo cat /etc/rancher/k3s/k3s.yaml
    ```
 
    {{% notice tip %}}
@@ -87,15 +87,9 @@ sudo $(which kubectl) scale statefulset {{< resource type="statefulset" name="mq
    environment and may differ.
    {{% /notice %}}
 
-2. Show the content of `k3s.yaml` with the following command and copy the output:
+2. Create a `.yaml` file on your local device and paste the content in it.
 
-   ```bash
-   sudo cat k3s.yaml
-   ```
-
-3. Create a `.yaml` file on your local device and paste the content in it.
-
-4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+3. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
 then save it:
       ```yaml
       apiVersion: v1
@@ -167,10 +161,10 @@ failure.
 
 ### Copy kubeconfig file
 
-1. Move to the folder on the server where the kubeconfig file is located:
+1. Show the content of kubeconfig file with the following command and copy the output:
 
    ```bash
-   cd /etc/rancher/k3s
+   sudo cat /etc/rancher/k3s/k3s.yaml
    ```
 
    {{% notice tip %}}
@@ -179,15 +173,9 @@ failure.
    environment and may differ.
    {{% /notice %}}
 
-2. Show the content of `k3s.yaml` with the following command and copy the output:
+2. Create a `.yaml` file on your local device and paste the content in it.
 
-   ```bash
-   sudo cat k3s.yaml
-   ```
-
-3. Create a `.yaml` file on your local device and paste the content in it.
-
-4. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
+3. Adjust the server's IP address under `clusters` &rArr; `cluster` &rArr; `server`, 
 then save it:
       ```yaml
       apiVersion: v1


### PR DESCRIPTION
# Description

- Given scripts are tested and updated the guide.
- Information about new scripts for `umh_v2` and companion is added

Before backup/restore, users must copy the ` kubeconfig` of instance and save it in local. I tried to write a script for that, but access from local to root directory of remote will be denied, so users have to do it manually.

## Related issues

close united-manufacturing-hub/MgmtIssues/issues/1339

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
