### PR TITLE
Add new firewall rules security page

### DIFF
--- a/umh.docs.umh.app/content/en/docs/getstarted/installation.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/installation.md
@@ -24,6 +24,13 @@ While UMH is optimized for RHEL and Flatcar, it can theoretically run on other L
 
 Note: Systems at the edge of these requirements may experience longer installation times. Close other programs during installation for optimal performance.
 
+## Network Requirements
+
+Before proceeding with the installation, ensure your system meets the necessary network requirements.
+
+To learn about configuring firewall and network rules for your UMH instances, please refer to our dedicated [Firewall Rules](/docs/production-guide/security/firewall-rules/)
+page.
+
 ## Installation Steps
 
 1. [Open the Management Console](https://management.umh.app/) in the browser.

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -15,16 +15,16 @@ To guarantee the security and seamless operation of your UMH instances, proper f
 
 Before proceeding with the firewall setup, it's worth discussing why they matter in the first place.
 
-As you may or may not know, the UMH consists of several open-source components, and the usage of these might require
-various rules for their proper operation. Considering the complexity involved in setting up and maintaining these
-rules, we have hosted as much as possible under our own domain (management.umh.app). This way, the setup is much
-simpler and less error-prone on your end.
+The usage of the components integrated into the UMH require various rules for their proper operation.
+Considering the complexity involved in setting up and maintaining these rules, we have hosted as much 
+as possible under our own domain (management.umh.app), which leads to a simpler and less error-prone
+setup.
 
-However, it's important to note that, despite our efforts to minimize external requests, some of the components may
-require occasional communication to their respective services. For example, installing plugins for applications like
-Grafana or Node-RED will likely involve requests to their respective domains. In such cases, this page provides a
-comprehensive list of external domains and ports that are relevant during the usage of the UMH, helping you to
-anticipate and configure the rules accordingly.
+However, it's important to note that, some components may require occasional communication to external 
+services. For example, installing plugins for applications like Grafana or Node-RED will likely trigger 
+requests to their respective domains. In such cases, this page provides a comprehensive list of external 
+domains and ports that are relevant during the usage of the UMH, helping you to anticipate and configure
+the rules accordingly.
 
 ## Firewall Configuration
 
@@ -32,12 +32,11 @@ Once you're ready and ensured that you have the necessary permissions to configu
 
 ### Whitelist Our Domain
 
-The first and most important step simply involves allowing access to our domain (management.umh.app) on the following ports:
+The first and most important step simply involves allowing access to our domain (management.umh.app) on the following port:
 
-- TCP port 80: HTTP traffic
 - TCP port 443: HTTPS traffic
 
-Ignoring this step or even worse, blocking access to our domain and corresponding ports, will result in a malfunctioning
+Ignoring this step or even worse, blocking access to our domain and corresponding port, will result in a malfunctioning
 UMH instance.
 
 ### Whitelist External Domains

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -9,45 +9,37 @@ weight: 50
 
 <!-- overview -->
 
-For closed enterprise networks with specific permissions, this page outlines firewall rule configuration
-to ensure the security and seamless operation of your UMH instances.
+Some enterprise networks operate in a whitelist manner, where all outgoing and incoming communication
+is blocked by default. However, the installation and maintenance of UMH requires internet access for
+tasks such as downloading the operating system, Docker containers, monitoring via the Management Console,
+and loading third-party plugins. As dependencies are hosted on various servers and may change based on
+vendors' decisions, we've simplified the user experience by consolidating all mandatory services under a
+single domain. Nevertheless, if you wish to install third-party components like Node-RED or Grafana plugins,
+you'll need to whitelist additional domains.
 
 ## {{% heading "prerequisites" %}}
 
-Before configuring the firewall, let's discuss some key points.
-
-The usage of the components integrated into the UMH require various rules for their proper operation.
-Considering the complexity involved in setting up and maintaining these rules, we have hosted as much
-as possible under our own domain (management.umh.app), which leads to a simpler and less error-prone
-setup.
-
-However, it's important to note that, some components may require occasional communication to external
-services. For example, installing plugins for applications like Grafana or Node-RED will likely trigger
-requests to their respective domains. In such cases, this page provides a comprehensive list of external
-domains and ports that are relevant during the usage of the UMH, helping you to anticipate and configure
-the rules accordingly.
+The only prerequisite is having a firewall that allows modification of rules. If you're unsure about this,
+consider contacting your network administrator.
 
 ## Firewall Configuration
 
 Once you're ready and ensured that you have the necessary permissions to configure the firewall, follow these steps:
 
-### Whitelist Our Domain
+### Whitelist management.umh.app
 
-The first and most important step simply involves allowing access to our domain (management.umh.app) on the following port:
+This mandatory step requires whitelisting `management.umh.app` on TCP port 443 (HTTPS traffic). Not doing so will
+disrupt UMH functionality; installations, updates, and monitoring won't work as expected.
 
-- TCP port 443: HTTPS traffic
+### Optional: Whitelist domains for common 3rd party plugins
 
-Ignoring this step or even worse, blocking access to our domain and corresponding port, will result in a malfunctioning
-UMH instance.
-
-### Whitelist External Domains
-
-This step lists the external domains and ports that are common while working with the UMH. Keep in mind that
-this list is not exhaustive, and you may need to add additional rules depending on your specific use case.
+Include these common external domains and ports in your firewall rules to allow installing Node-RED and Grafana plugins:
 
 - registry.npmjs.org
 - storage.googleapis.com
 - grafana.com
+
+Depending on your setup, additional domains may need to be whitelisted.
 
 ## DNS Configuration (Optional)
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -45,13 +45,14 @@ Depending on your setup, additional domains may need to be whitelisted.
 
 ## DNS Configuration (Optional)
 
-By default, we make use of the following DNS servers:
+By default, we are using your DHCP configured DNS servers. If you are using static ip or want to use a different DNS server,
+contact us for a custom configuration file.
 
-- 1.1.1.1
-- 1.0.0.1 (fallback)
+## Bring your own containers
 
-Ensure that these DNS servers are accessible and not blocked by your enterprise network. Additionally, check for any
-custom DNS servers configured on your machine. If these are blocked, it may restrict the functionality of your UMH instances.
+Our system tries to fetch all containers from our own registry (management.umh.app) first.
+If this fails, it will try to fetch docker.io from `https://registry-1.docker.io`, ghcr.io from `https://ghcr.io` and quay.io from `https://quay.io` (and any other from `management.umh.app`)
+If you need to use a different registry, edit the `/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl` to set your own mirror configuration.
 
 ## {{% heading "troubleshooting" %}}
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -9,7 +9,8 @@ weight: 50
 
 <!-- overview -->
 
-To guarantee the security and seamless operation of your UMH instances, proper firewall rules must be configured.
+For closed enterprise networks with specific permissions, this page outlines firewall rule configuration 
+to ensure the security and seamless operation of your UMH instances.
 
 ## {{% heading "prerequisites" %}}
 
@@ -44,7 +45,9 @@ UMH instance.
 This step lists the external domains and ports that are common while working with the UMH. Keep in mind that
 this list is not exhaustive, and you may need to add additional rules depending on your specific use case.
 
-- TODO: Add list of external domains and ports
+- registry.npmjs.org
+- storage.googleapis.com
+- grafana.com
 
 ## {{% heading "troubleshooting" %}}
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -1,0 +1,62 @@
+---
+title: "Firewall Rules"
+menuTitle: "Firewall Rules"
+description: |
+  This page describes how to setup firewall rules for the UMH instances.
+content_type: task
+weight: 50
+---
+
+<!-- overview -->
+
+To guarantee the security and seamless operation of your UMH instances, proper firewall rules must be configured.
+
+## {{% heading "prerequisites" %}}
+
+Before proceeding with the firewall setup, it's worth discussing why they matter in the first place.
+
+As you may or may not know, the UMH consists of several open-source components, and the usage of these might require
+various rules for their proper operation. Considering the complexity involved in setting up and maintaining these
+rules, we have hosted as much as possible under our own domain (management.umh.app). This way, the setup is much
+simpler and less error-prone on your end.
+
+However, it's important to note that, despite our efforts to minimize external requests, some of the components may
+require occasional communication to their respective services. For example, installing plugins for applications like
+Grafana or Node-RED will likely involve requests to their respective domains. In such cases, this page provides a
+comprehensive list of external domains and ports that are relevant during the usage of the UMH, helping you to
+anticipate and configure the rules accordingly.
+
+## Firewall Configuration
+
+Once you're ready and ensured that you have the necessary permissions to configure the firewall, follow these steps:
+
+### Whitelist Our Domain
+
+The first and most important step simply involves allowing access to our domain (management.umh.app) on the following ports:
+
+- TCP port 80: HTTP traffic
+- TCP port 443: HTTPS traffic
+
+Ignoring this step or even worse, blocking access to our domain and corresponding ports, will result in a malfunctioning
+UMH instance.
+
+### Whitelist External Domains
+
+This step lists the external domains and ports that are common while working with the UMH. Keep in mind that
+this list is not exhaustive, and you may need to add additional rules depending on your specific use case.
+
+- TODO: Add list of external domains and ports
+
+## {{% heading "troubleshooting" %}}
+
+### I'm having connectivity problems. What should I do?
+
+First of all, double-check that your firewall rules are configured as described in this page, especially the step
+involving our domain. As a quick test, you can use the following command from a different machine within the same
+network to check if the rules are working:
+
+```bash
+curl -vvv https://management.umh.app
+```
+
+<!-- Add more troubleshooting steps? -->

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -35,9 +35,11 @@ disrupt UMH functionality; installations, updates, and monitoring won't work as 
 
 Include these common external domains and ports in your firewall rules to allow installing Node-RED and Grafana plugins:
 
-- registry.npmjs.org
-- storage.googleapis.com
-- grafana.com
+- registry.npmjs.org (required for installing Node-RED plugins)
+- storage.googleapis.com (required for installing Grafana plugins)
+- grafana.com (required for displaying Grafana plugins)
+- catalogue.nodered.org (required for displaying Node-RED plugins, only relevant for the client that is using Node-RED, not
+  the server where it's installed on).
 
 Depending on your setup, additional domains may need to be whitelisted.
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -13,7 +13,7 @@ To guarantee the security and seamless operation of your UMH instances, proper f
 
 ## {{% heading "prerequisites" %}}
 
-Before proceeding with the firewall setup, it's worth discussing why they matter in the first place.
+Before configuring the firewall, let's discuss some key points.
 
 The usage of the components integrated into the UMH require various rules for their proper operation.
 Considering the complexity involved in setting up and maintaining these rules, we have hosted as much 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -9,7 +9,7 @@ weight: 50
 
 <!-- overview -->
 
-For closed enterprise networks with specific permissions, this page outlines firewall rule configuration 
+For closed enterprise networks with specific permissions, this page outlines firewall rule configuration
 to ensure the security and seamless operation of your UMH instances.
 
 ## {{% heading "prerequisites" %}}
@@ -17,13 +17,13 @@ to ensure the security and seamless operation of your UMH instances.
 Before configuring the firewall, let's discuss some key points.
 
 The usage of the components integrated into the UMH require various rules for their proper operation.
-Considering the complexity involved in setting up and maintaining these rules, we have hosted as much 
+Considering the complexity involved in setting up and maintaining these rules, we have hosted as much
 as possible under our own domain (management.umh.app), which leads to a simpler and less error-prone
 setup.
 
-However, it's important to note that, some components may require occasional communication to external 
-services. For example, installing plugins for applications like Grafana or Node-RED will likely trigger 
-requests to their respective domains. In such cases, this page provides a comprehensive list of external 
+However, it's important to note that, some components may require occasional communication to external
+services. For example, installing plugins for applications like Grafana or Node-RED will likely trigger
+requests to their respective domains. In such cases, this page provides a comprehensive list of external
 domains and ports that are relevant during the usage of the UMH, helping you to anticipate and configure
 the rules accordingly.
 
@@ -48,6 +48,16 @@ this list is not exhaustive, and you may need to add additional rules depending 
 - registry.npmjs.org
 - storage.googleapis.com
 - grafana.com
+
+## DNS Configuration (Optional)
+
+By default, we make use of the following DNS servers:
+
+- 1.1.1.1
+- 1.0.0.1 (fallback)
+
+Ensure that these DNS servers are accessible and not blocked by your enterprise network. Additionally, check for any
+custom DNS servers configured on your machine. If these are blocked, it may restrict the functionality of your UMH instances.
 
 ## {{% heading "troubleshooting" %}}
 

--- a/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
+++ b/umh.docs.umh.app/content/en/docs/production-guide/security/firewall-rules.md
@@ -50,7 +50,7 @@ contact us for a custom configuration file.
 
 ## Bring your own containers
 
-Our system tries to fetch all containers from our own registry (management.umh.app) first.
+Our system tries to fetch all containers from our own registry (`management.umh.app`) first.
 If this fails, it will try to fetch docker.io from `https://registry-1.docker.io`, ghcr.io from `https://ghcr.io` and quay.io from `https://quay.io` (and any other from `management.umh.app`)
 If you need to use a different registry, edit the `/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl` to set your own mirror configuration.
 


### PR DESCRIPTION
# Description

This PR adds a new "Firewall Rules" page under ProductionGuide/Security, which explains how to setup proper firewall rules for well functioning UMH instances.

## Related issues

- Closes https://github.com/united-manufacturing-hub/MgmtIssues/issues/1468
- Closes https://github.com/united-manufacturing-hub/MgmtIssues/issues/1471

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

- Please double-check the mentioned ports in the "Whitelist our Domain" step, as I'm not 100% sure about the necessary ports.
- The "Whitelist External Domains" includes domains that were reported through PCAP recording while following the get started guide as a whole. Pretty much the two components that request external services are Grafana and Node-RED (installing plugins in both Grafana and Node-Red, grafana's home page display their blog posts, etc.)
- Feel free to offer any other useful troubleshooting steps that might be relevant.
