### PR TITLE
Update data dashboard references to mention tag browser instead

### DIFF
--- a/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
+++ b/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
@@ -43,18 +43,21 @@ deploy a data source.
 After logging in, the Instance Dashboard page shows the **Overview** tab.
 You can click and open each status on this tab.
 
-![Instance Overview](/images/features/monitor-management/instanceOverview.png?width=80%)
+![Instance Overview](/images/features/monitor-management/instanceOverviewDemo.png?width=80%)
 
 The **Connection Management** tab shows the status of all the instance's connections and their associated
 data sources. Moreover, you can create a new connection, as well as initialize them.
 Read more about the Connection Management in the [Connectivity](/docs/features/connectivity/) section.
 
-![Connection Management](/images/features/monitor-management/instanceConnectionManagement.png?width=80%)
+![Connection Management](/images/features/monitor-management/connectionManagementDemo.png?width=80%)
 
-The Data Dashboard displays the topic structure and publisher & subscriber
-information.
+<!-- TODO: Mention the payload's values history feature once implemented -->
 
-![Data Dashboard](/images/features/monitor-management/dataDashboard.png?width=80%)
+The **Tag Browser** displays the topic structure and publisher & subscriber
+information. Read more about the Tag Browser in the [Unified Namespace](/docs/features/datainfrastructure/unified-namespace)
+section.
+
+![Tag Browser](/images/features/monitor-management/tagBrowser.png?width=80%)
 
 ## What are the limitations?
 

--- a/umh.docs.umh.app/content/en/docs/getstarted/dataacquisitionmanipulation.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/dataacquisitionmanipulation.md
@@ -341,6 +341,13 @@ Consider adding a debug node for visualizing output data.
 
 ![Node-RED Kafka to Kafka](/images/getstarted/dataAcquisitionManipulation/noderedKafkaKafka.png?width=80%)
 
+## Tag Browser
+
+Returning to the Management Console, you'll find the output data displayed within the **Tag Browser**,
+which offers a user-friendly tree structure for browsing the topic hierarchy we defined in previous steps.
+
+![Tag Browser](/images/getstarted/dataAcquisitionManipulation/tagBrowserTemperature.png?width=80%)
+
 ## {{% heading "whatsnext" %}}
 
 Next, we'll dive into [Data Visualization](/docs/getstarted/datavisualization),

--- a/umh.docs.umh.app/content/en/docs/getstarted/datavisualization.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/datavisualization.md
@@ -62,7 +62,7 @@ both of which were established in the previous chapter.
 In the code snippet above, the arguments provided to the function are based on the OPC-UA node we defined in the
 [**Initialize the Connection**](/docs/getstarted/dataacquisitionmanipulation/#initialize-the-connection)
 section of the previous chapter, so adjust them accordingly if you used different values, these values can also be
-found at the **data dashboard** of the **Management Console**, which displays all OPC-UA nodes in a tree structure.
+found at the **Tag Browser** of the **Management Console**, which displays all OPC-UA nodes in a tree structure.
 {{% /notice %}}
 
 11. Same as before, click on the **Run Query** button to execute the query. If you've been following along, you won't

--- a/umh.docs.umh.app/content/en/docs/getstarted/managingthesystem.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/managingthesystem.md
@@ -32,7 +32,7 @@ For more information, visit the [architecture](/docs/architecture/)
 
 ## Overview of Your Instances
 
-![Instance overview](/images/getstarted/managingTheSystem/instanceOverview.png?width=80%)
+![Instance overview](/images/features/monitor-management/instanceOverviewDemo.png?width=80%)
 
 On the left side of the Management Console, you can view the list of your
 instances. If you have just installed the UMH, you should see only one instance

--- a/umh.docs.umh.app/static/images/features/monitor-management/connectionManagementDemo.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/connectionManagementDemo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8d99fb78b3753ab2be8c005a6932e2443e34e74c723fdce6c0f16901f5f6c42
+size 65077

--- a/umh.docs.umh.app/static/images/features/monitor-management/dataDashboard.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/dataDashboard.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ca21a9cf78ae0fc66da3281895d15a6e9da0cf1b1dfff9d8a861f5428d2c96f
-size 53557

--- a/umh.docs.umh.app/static/images/features/monitor-management/instanceConnectionManagement.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/instanceConnectionManagement.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2676d942238ce48507367b44dfd80889cf0f018d39b36197f05712709fbc1023
-size 48098

--- a/umh.docs.umh.app/static/images/features/monitor-management/instanceOverview.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/instanceOverview.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53badb7e854458f3b319ba12cfb459fb6b28d27b488d975a7029d859180bc4d9
-size 70479

--- a/umh.docs.umh.app/static/images/features/monitor-management/instanceOverviewDemo.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/instanceOverviewDemo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e108894489ef35841efeb2ede46df3f996a13d2b1fb82a2aa1bd157cfc1d7251
+size 63982

--- a/umh.docs.umh.app/static/images/features/monitor-management/tagBrowser.png
+++ b/umh.docs.umh.app/static/images/features/monitor-management/tagBrowser.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bef72bba001ae28e2a3b86c00fc35a5fad50a4d33da8baf984da3ffe513f371
+size 65002

--- a/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagement.png
+++ b/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagement.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f7e9cface5c032b66a17e8dd7a15d150d86975e719909c1468ef8d6f6a264490
-size 33557
+oid sha256:a4a366dce3524b9996c38d1edf104898b0689081cdd67948290552d7c57d05db
+size 33343

--- a/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagementHealthy.png
+++ b/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagementHealthy.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9525ad77eb198a68cc928ca03c083aff840f5c392666b4534bf207dbd520a7dc
-size 34022
+oid sha256:db4975c064ab8a0ba81c96594c253d3ae4f524d09d0019718ca56e25204b3599
+size 33971

--- a/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagementInitializeButton.png
+++ b/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/connectionManagementInitializeButton.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41261d100606d57f10e94b7227ebb44787b63764feaf33f94de49c613ee2fce8
-size 33610
+oid sha256:550c45ba00cd51dfaf7451fad67e70186c8445d998f45f80f1ec74b7fdb96284
+size 33599

--- a/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/tagBrowserTemperature.png
+++ b/umh.docs.umh.app/static/images/getstarted/dataAcquisitionManipulation/tagBrowserTemperature.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac94b4a7ddd493c3aa865c68fe3e639a480b4a153ad3d6f48a1fcdae70121ab
+size 51105

--- a/umh.docs.umh.app/static/images/getstarted/installation/instanceOverview.png
+++ b/umh.docs.umh.app/static/images/getstarted/installation/instanceOverview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f793c1709eb5dd7afdef95abd05c8ed4f591f4b06af51ec50c6eae8f329231a4
-size 55501
+oid sha256:029aabc0b8e90e46128843390f86ba68a21b412a755321088dd7b6c7bfed0541
+size 54456


### PR DESCRIPTION
# Description

This PR went through a couple of pages of the current docs where the data dashboard is mentioned, and replaces them with the tag browser. I also updated a couple of pictures in the getstarted guide where the data dashboard was still visible.

I also added a `tag browser` section at the end of the [Data Acquisition and Manipulation](https://umh.docs.umh.app/docs/getstarted/dataacquisitionmanipulation/) page, right after the `Node-RED` section, to reflect that produced output data also appears there.

## Related issues

- Closes https://github.com/united-manufacturing-hub/MgmtIssues/issues/1639

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

