### PR TITLE
Provide better explanations of the tag browser, including examples

### DIFF
--- a/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
+++ b/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
@@ -51,10 +51,22 @@ Read more about the Connection Management in the [Connectivity](/docs/features/c
 
 ![Connection Management](/images/features/monitor-management/connectionManagementDemo.png?width=80%)
 
-<!-- TODO: Mention the payload's values history feature once implemented -->
+The **Tag Browser** provides a comprehensive view of the tag structure, allowing automation engineers to
+manage and navigate through all their tags without concerning themselves with underlying technical complexities,
+such as topics, keys or payload structures.
 
-The **Tag Browser** displays the topic structure and publisher & subscriber
-information. Read more about the Tag Browser in the [Unified Namespace](/docs/features/datainfrastructure/unified-namespace)
+Tags typically represent variables associated with devices in an ISA-95 model.
+For instance, it could represent a temperature reading from a specific sensor or a status indication from
+a machine component. These tags are transported through various technical methods across the Unified
+Namespace (UNS) into the database. This includes organizing them within a folder structure or embedding them
+as JSON objects within the message payload. Tags can be sent into the same topic or utilizing various sub-topics.
+Due to the nature of MQTT and Kafka, the topics may differ, but the following formula applies:
+
+```text
+MQTT Topic = Kafka topic + Kafka Key
+```
+
+Read more about the Tag Browser in the [Unified Namespace](/docs/features/datainfrastructure/unified-namespace)
 section.
 
 ![Tag Browser](/images/features/monitor-management/tagBrowser.png?width=80%)

--- a/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
+++ b/umh.docs.umh.app/content/en/docs/features/devicecontainerinfrastructure/monitoring.md
@@ -66,6 +66,11 @@ Due to the nature of MQTT and Kafka, the topics may differ, but the following fo
 MQTT Topic = Kafka topic + Kafka Key
 ```
 
+{{% notice info %}}
+The kafka topic and key depend on the configured merge point, read more about it 
+[here](/docs/production-guide/administration/normalize-kafka-topics).
+{{% /notice %}}
+
 Read more about the Tag Browser in the [Unified Namespace](/docs/features/datainfrastructure/unified-namespace)
 section.
 

--- a/umh.docs.umh.app/content/en/docs/getstarted/dataacquisitionmanipulation.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/dataacquisitionmanipulation.md
@@ -344,7 +344,7 @@ Consider adding a debug node for visualizing output data.
 ## Tag Browser
 
 Returning to the Management Console, you'll find the output data displayed within the **Tag Browser**,
-which offers a user-friendly tree structure for browsing the topic hierarchy we defined in previous steps.
+which offers a user-friendly tree structure for browsing the tag hierarchy we defined in previous steps.
 
 ![Tag Browser](/images/getstarted/dataAcquisitionManipulation/tagBrowserTemperature.png?width=80%)
 


### PR DESCRIPTION
# Description
Thir PR addresses some comments that were made on https://github.com/united-manufacturing-hub/umh.docs.umh.app/pull/244, mainly improving the explanation of the Tag Browser in the [monitoring](https://umh.docs.umh.app/docs/features/devicecontainerinfrastructure/monitoring/) page, including examples and more details about what a tag actually is.

## Related issues

- Closes https://github.com/united-manufacturing-hub/MgmtIssues/issues/1639

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
