### PR TITLE
List more tag browser features and update the tag browser screnshot

### DIFF
--- a/umh.docs.umh.app/content/en/docs/features/datainfrastructure/unified-namespace.md
+++ b/umh.docs.umh.app/content/en/docs/features/datainfrastructure/unified-namespace.md
@@ -99,6 +99,10 @@ following features:
   and the full tag name to uniquely identify the selected tag.
 - **Payload Visualization**: Displays payloads under validated schemas in a formatted/structured manner, enhancing
   readability. For unknown schemas without strict validation, the raw payload is displayed instead.
+- **Tag Value History**: Shows the last 100 received values for the selected tag, allowing you to track the
+  changes in the data over time. Keep in mind that this feature is only available for tags that are part of the
+  `_historian` schema.
+- **Kafka Origin**: Provides information about the Kafka key, topic and the actual payload that was sent via Kafka.
 
 {{% notice note %}}
 It's important to note that data displayed in the `Tag Browser` represent snapshots; hence, data sent at

--- a/umh.docs.umh.app/static/images/features/unified-namespace/tagBrowser.png
+++ b/umh.docs.umh.app/static/images/features/unified-namespace/tagBrowser.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8bef72bba001ae28e2a3b86c00fc35a5fad50a4d33da8baf984da3ffe513f371
-size 65002
+oid sha256:3a227d71f75c5c5cad92ee713eeadff9e6574539f91ed57d132b5da7c10710ad
+size 181256


### PR DESCRIPTION
# Description

This PR lists two more tag browser features that have been recenty implemented:

- The values history (last 100 values)
- The "Inserted as" collaspible that contains the kafka key, topic and the payload that it sends.

## Related issues

Linked to https://github.com/united-manufacturing-hub/MgmtIssues/issues/1634

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.