### PR TITLE
Fix code of conduct link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 *You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*
 
-- [ ] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](./CODE_OF_CONDUCT.md).
+- [ ] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](https://github.com/united-manufacturing-hub/umh.docs.umh.app/blob/main/.github/CODE_OF_CONDUCT.md).
 - [ ] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
 
 ## Additional information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 *You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*
 
-- [ ] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](CODE_OF_CONDUCT.md).
+- [ ] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](./CODE_OF_CONDUCT.md).
 - [ ] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
 
 ## Additional information


### PR DESCRIPTION
# Description

Fixing the link by making it absolute, so it links correctly regardless of the rendering URL.

## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](./CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

<!-- Enter here any additional information that might be useful -->
