### PR TITLE
Add tag error tracing to tag browser feature list

### DIFF
--- a/umh.docs.umh.app/content/en/docs/features/datainfrastructure/unified-namespace.md
+++ b/umh.docs.umh.app/content/en/docs/features/datainfrastructure/unified-namespace.md
@@ -94,6 +94,9 @@ following features:
 - **Tag Folder Structure**: Facilitates browsing through tag folders or groups within a single asset.
 - **Schema validation**: Introduces validation for known schemas such as `_historian`. In case of validation
   failure, the corresponding errors are displayed.
+- **Tag Error Tracing**: Enables error tracing within the Unified Namespace tree. When errors are detected in tags
+  or schemas, all affected nodes are highlighted with warnings, making it easier to track down the troubled
+  source tags or schemas.
 - **Publisher & Subscriber Info**: Provides various details, such as the origins and destinations of the data,
   the instance it was published from, the messages per minute to get an overview on how much data is flowing,
   and the full tag name to uniquely identify the selected tag.


### PR DESCRIPTION
# Description

This PR adds the newly implemented tag error tracing functionality that was implemented to the tag browser's tree view, to the tag browser features list.

## Related issues

- https://github.com/united-manufacturing-hub/MgmtIssues/issues/1927

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](https://github.com/united-manufacturing-hub/umh.docs.umh.app/blob/main/.github/CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
