### PR TITLE
Fix broken link in architecture docs

### DIFF
--- a/umh.docs.umh.app/content/en/docs/architecture/_index.md
+++ b/umh.docs.umh.app/content/en/docs/architecture/_index.md
@@ -341,7 +341,7 @@ integral to UMH.
 
 ## Device & Container Infrastructure
 
-The [Device & Container Infrastructure](/docs/architecture/device-&-container-infrastructure)
+The [Device & Container Infrastructure](/docs/architecture/device--container-infrastructure)
 lays the foundation of the United Manufacturing Hub's architecture, streamlining
 the deployment and setup of essential software and operating systems across devices.
 This infrastructure is pivotal in automating the installation process, ensuring


### PR DESCRIPTION
# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
     Remember to also add relevant labels. -->

The _Device & Container Infrastructure_ link in the [architecture docs](https://umh.docs.umh.app/docs/architecture/?ref=learn.umh.app#device--container-infrastructure) currently leads to https://umh.docs.umh.app/docs/architecture/device-&-container-infrastructure, which doesn't exist. The correct link is https://umh.docs.umh.app/docs/architecture/device--container-infrastructure/ 


## Related issues

<!-- Link to the issues that are related to this pull request. -->

## Checklist

*You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](https://github.com/united-manufacturing-hub/umh.docs.umh.app/blob/main/.github/CODE_OF_CONDUCT.md).
- [x] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.

## Additional information

<!-- Enter here any additional information that might be useful -->
