### PR TITLE
docs: correct typo in datavisualization

### DIFF
--- a/umh.docs.umh.app/content/en/docs/getstarted/datavisualization.md
+++ b/umh.docs.umh.app/content/en/docs/getstarted/datavisualization.md
@@ -13,7 +13,7 @@ both of which were established in the previous chapter.
 ## Creating a Grafana dashboard
 
 1. If you haven't done so already, open and log in to Grafana by following the instructions given in the
-   [**Acess Grafana**](/docs/getstarted/managingthesystem/#access-grafana) section of chapter 2.
+   [**Access Grafana**](/docs/getstarted/managingthesystem/#access-grafana) section of chapter 2.
 
 2. Once logged in, hover over the fourth icon in the left menu,
    **dashboards**, and click on **+ New dashboard**.


### PR DESCRIPTION
# Description

Fixed a typo in datavisualization.md where hyperlink was "Acess Grafana" rather than "Access Grafana"

## Related issues

Fix #300 

## Checklist

- [x] I have read the [contributing guidelines](https://umh.docs.umh.app/docs/development/contribute/new-content/add-documentation/) and the [code of conduct](https://github.com/united-manufacturing-hub/umh.docs.umh.app/blob/main/.github/CODE_OF_CONDUCT.md).
- [X] I have followed the [documentation](https://umh.docs.umh.app/docs/development/contribute/documentation/style/) style.
